### PR TITLE
Affichage des données selon le mouvement sur la carte

### DIFF
--- a/addons/cartohoraires/js/main.js
+++ b/addons/cartohoraires/js/main.js
@@ -7,18 +7,32 @@ const cartohoraires = (function() {
     let requestLayer = options.requestLayer;
 
     let zacLayer = null;
-    let selected = null;
 
-        /**
-     * PRIVATE
+    const zacHighlightStyle = new ol.style.Style({
+        fill: new ol.style.Fill({
+          color: 'rgba(255, 255, 255, 0)',
+        }),
+        stroke: new ol.style.Stroke({
+          color: 'rgb(255, 145, 0)',
+          width: 2,
+        })
+    });
+
+    /**
+    * PRIVATE
     */
+
+    function initSRS3948() {
+        proj4.defs("EPSG:3948","+proj=lcc +lat_1=47.25 +lat_2=48.75 +lat_0=48 +lon_0=3 +x_0=1700000 +y_0=7200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs");
+        ol.proj.proj4.register(proj4);
+    }
 
     /**
      * Standardize request creation
      * @param {Object} infos as data params
      * @param {*} successFunc as callback function
      */
-    const createRequest = function(infos, successFunc) {
+    function createRequest (infos, successFunc) {
         return {
             url: infos.url,
             data: infos.data,
@@ -31,7 +45,7 @@ const cartohoraires = (function() {
     /**
      * Request to call Mustache template from server or local path.
      */
-    const initTemplate = function() {
+    function initTemplate () {
         let req = createRequest({
             url: options.template,
             success: function(template) {
@@ -132,57 +146,148 @@ const cartohoraires = (function() {
         $('.bootstrap-autocomplete.dropdown-menu').css('width','100%');
     }
 
-    function displayResult() {
+    /**
+     * From Sirene or Address API, we zoom on result feature
+     * @param {ol.Feature} selected 
+     */
+    function displayResult(selected) {
         if(selected) {
            var geom = selected.geometry.coordinates;
            mviewer.zoomToLocation(geom[0], geom[1], 16, null);
         }
     }
 
-    function setSelected(e) {return selected = e;}
+    /**
+     * From geom we retrieve geoserver data by contains method
+     * @param {String} wkt as geom string
+     */
+    function getDataByGeom(wkt) {
+        let request = createRequest({
+            url: 'https://public-test.sig.rennesmetropole.fr/geoserver/ows',
+            data: {
+                SERVICE: "WFS",
+                VERSION: "1.1.0",
+                REQUEST: "GetFeature",
+                TYPENAME: `v_horaires`,
+                OUTPUTFORMAT: "application/json",
+                CQL_FILTER: `Intersects(shape, ${wkt})`
+            },
+            success: function (results) {
+                if(results.features && results.features.length) {
+                    setInfoData(results.features);
+                }
+            }
+        });
+
+        request.type = 'GET';
+        $.ajax(request);
+    };
+
+    /**
+     * Transform coordinates Array to WKT
+     * @param {Array} coord 
+     * @param {String} Type as POLYGON, POINT or other available openLayers Geom Type
+    */
+    function coordinatesToWKT(coord, type) {
+        return `${type}((${coord.map(e => `${e[0]} ${e[1]}`).join(',')}))`;
+    };
+
+    /**
+     * From Map center, we retrieve geoserver feature by intersection method
+     * @param {Array} center 
+     */
+    function getZacByPoint(center) {
+        if(!center.length) {
+            return;
+        }
+        var cc48Center = ol.proj.transform([center[0],center[1]], 'EPSG:3857', 'EPSG:3948');
+        let request = createRequest({
+            url: 'https://public.sig.rennesmetropole.fr/geoserver/ows',
+            data: {
+                SERVICE: "WFS",
+                VERSION: "1.1.0",
+                REQUEST: "GetFeature",
+                TYPENAME: `eco_comm:v_za_terminee`,
+                OUTPUTFORMAT: "application/json",
+                CQL_FILTER: `Intersects(shape, POINT(${cc48Center[0]} ${cc48Center[1]}))`
+            },
+            success: function (results) {
+                if(results.features && results.features.length) {
+                    // get geom coordinates as string
+                    let wktGeom = coordinatesToWKT(results.features[0].geometry.coordinates[0][0], 'POLYGON')
+
+                    // add to layer to highlight feature
+                    let zac3857 = new ol.Feature(
+                        new ol.geom.Polygon(results.features[0].geometry.coordinates[0]).clone().transform('EPSG:3948','EPSG:3857')
+                    );
+                    zacLayer.getSource().clear(); // cremove all features
+                    zacLayer.getSource().addFeature(zac3857); // add this
+                    
+                    // get data by geoserver request
+                    getDataByGeom(wktGeom);
+                }
+            }
+        });
+
+        request.type = 'GET';
+        $.ajax(request);
+    }
+
+    function getDataByExtent() {
+        let extentMap = mviewer.getMap().getView().calculateExtent(mviewer.getMap().getSize());
+        turfPolygon = turf.bboxPolygon(extentMap);
+
+        let bboxFeature = new ol.format.GeoJSON().readFeatures(turfPolygon);
+        let bboxCoord = bboxFeature[0].getGeometry().transform('EPSG:3857','EPSG:3948').getCoordinates()[0];
+        getDataByGeom(coordinatesToWKT(bboxCoord, 'POLYGON'));
+    }
+
+    /**
+     * Init event to trigger behavior on map move end action
+     */
+    function initMoveBehavior() {
+        mviewer.getMap().on('moveend', function() {
+            zacLayer.getSource().clear(); // cremove all features
+            $('#temp-infos').text('');
+
+            if($('#switch').is(':checked')) {
+                getZacByPoint(mviewer.getMap().getView().getCenter());
+            } else {
+                getDataByExtent();
+            }
+        });
+    }
+
+    function setInfoData(features) {
+        $('#temp-infos').text('');
+        $('#temp-infos').text('Nombre d\'objets à l\'écran : ' + features.length.toString());
+    }
 
     function initZacLayer() {
-        var data = 'apps/cartoHoraires/data/zac_rm.geojson';
-        zacLayer = new ol.layer.Vector({
+        // display zac layer temporary
+        var data = 'https://public.sig.rennesmetropole.fr/geoserver/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=eco_comm:v_za_terminee&outputFormat=application%2Fjson&srsname=EPSG:3857';
+        var zacTempLayer = new ol.layer.Vector({
             source: new ol.source.Vector({
                 url: data,
                 format: new ol.format.GeoJSON()
             })
         });
-        mviewer.getMap().addLayer(zacLayer);
-    }
+        mviewer.getMap().addLayer(zacTempLayer);
 
-    function initMoveBehavior() {
-        mviewer.getMap().on('moveend', function() {
-            center = turf.point(mviewer.getMap().getView().getCenter());
-            let turfPolygon;
-            if($('#switch').is(':checked')) {
-                zacLayer.getSource().getFeatures().forEach(e => {
-                    let polygon = turf.polygon(e.getGeometry().getCoordinates()[0]);
-                    if(turf.booleanContains(polygon, center)){
-                        turfPolygon = polygon;
-                        $('#temp-infos').text('');
-                        $('#temp-infos').text(`Nb. saisies dans la ZA - ${e.getProperties().nomza} (${e.getProperties().nom_com}) : `);
-                    }
-                });
-            } else {
-                let extentMap = mviewer.getMap().getView().calculateExtent(mviewer.getMap().getSize());
-                turfPolygon = turf.bboxPolygon(extentMap);
-                $('#temp-infos').text('');
-                $('#temp-infos').text('Nb. saisies visibles à l\'écran : ');
+
+        if(!zacLayer) {
+            zacLayer = new ol.layer.Vector({
+                source: new ol.source.Vector({
+                  format: new ol.format.GeoJSON()
+                }),
+                style: function (feature) {
+                  return zacHighlightStyle;
+                }
+            });
+            if(mviewer.getMap()) {
+                mviewer.getMap().addLayer(zacLayer);
             }
-            setInfoData(turfPolygon); // search request infos from this polygon and display to template
-        });
-    }
-
-    function setInfoData(polygon) {
-        if(!polygon){return};
-        let features = mviewer.getLayers()[requestLayer].layer.getSource().getSource().getFeatures();
-        let findFeatures = features.filter(e => turf.booleanContains(polygon, turf.point(e.getGeometry().getCoordinates())))
-        let txt = $('#temp-infos').text();
-        txt += findFeatures.length.toString();
-        $('#temp-infos').text('');
-        $('#temp-infos').text(txt);
+        }
     }
 
     /**
@@ -192,18 +297,19 @@ const cartohoraires = (function() {
     return {
         init: () => {
             mviewer.getMap().once('postrender', m => {
+                initSRS3948();
                 initTemplate();
                 initDisplayComponents();
                 initModalBehavior();
                 initZacLayer();
-                initMoveBehavior();                
+                initMoveBehavior();
+                getDataByExtent();
             });
             initSearchItem();
         },
         searchBehavior : function(e) {
             if(e) {
-                setSelected(e);
-                displayResult();
+                displayResult(e);
             }
         }
     };

--- a/addons/mir/mir.js
+++ b/addons/mir/mir.js
@@ -1,30 +1,46 @@
-(function() {
-    var map = mviewer.getMap();
-
-    var element = () => {return document.getElementById('mir-marker')};
-
-    var options = mviewer.customComponents.mir.config.options;
-
-    var marker = new ol.Overlay({
-        position: map.getView().getCenter(),
-        positioning: 'center-center',
-        element: document.getElementById('mir-marker'),
-        stopEvent: false
-    });
-
-    map.addOverlay(marker);
+const mir = (function() {
+    let map = mviewer.getMap();
+    const element = () => {return document.getElementById('mir-marker')};
+    const options = mviewer.customComponents.mir.config.options;
+    let isVisible = null;
     
-    map.on('postrender', m => {
-        if(element()) {
-            if(!marker.getElement()) {
-                marker.setElement(document.getElementById('mir-marker'));
-            }
-            marker.setPosition(map.getView().getCenter())
-            if(options.maxzoom && map.getView().getZoom() <= options.maxzoom) {
-                element().style.display='none';
-            } else {
-                element().style.display='block';
-            }
+    return {
+        init: () => {
+            let marker = new ol.Overlay({
+                position: map.getView().getCenter(),
+                positioning: 'center-center',
+                element: document.getElementById('mir-marker'),
+                stopEvent: false
+            });
+        
+            map.addOverlay(marker);
+            
+            map.on('postrender', m => {
+                if(element()) {
+                    if(!marker.getElement()) {
+                        marker.setElement(document.getElementById('mir-marker'));
+                    }
+                    marker.setPosition(map.getView().getCenter())
+                    if(options.maxzoom && map.getView().getZoom() <= options.maxzoom) {
+                        element().style.display='none';
+                    } else {
+                        element().style.display='block';
+                    }
+
+                    if(isVisible === false) {
+                        element().style.display='none';
+                    }
+                }
+            });
+        },
+
+        deactivate: () => {
+            isVisible = false;
+        },
+
+        activate: () => {
+            isVisible = true;
         }
-    });
+    };
 })();
+new CustomComponent("mir", mir.init);

--- a/customlayers/etablissements.js
+++ b/customlayers/etablissements.js
@@ -1,6 +1,6 @@
 mviewer.customLayers.etablissements = (function () {
     var id = 'etablissements';
-    var data = 'apps/cartoHoraires/data/etablissements.geojson';
+    var data = 'https://public-test.sig.rennesmetropole.fr/geoserver/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=v_horaires&outputFormat=application%2Fjson&srsname=EPSG:3857';
     
     function manyStyle (radius, size, color) {
       return [
@@ -37,6 +37,7 @@ mviewer.customLayers.etablissements = (function () {
       var max_radius = 25;
       var max_value = 500;
       var radius = 10 + Math.sqrt(size)*(max_radius / Math.sqrt(max_value));
+      radius = radius * 0.4;
       var color = '#53B3B8';
 
       if(size > 1) {
@@ -46,13 +47,15 @@ mviewer.customLayers.etablissements = (function () {
       }
     }
 
+    var vectorSource = new ol.source.Vector({
+      url: data,
+      format: new ol.format.GeoJSON()
+    });
+
     var vectorLayer = new ol.layer.Vector({
       source: new ol.source.Cluster({
           distance: 0,
-          source: new ol.source.Vector({
-              url: data,
-              format: new ol.format.GeoJSON()
-          })
+          source: vectorSource
       }),
       style: clusterStyle
     });


### PR DESCRIPTION
- Afficher les infos du volet d'information selon la ZAC sous le centre de la map (intersect) ou selon l'emprise de la carte.
- Utilisation des données des Geo Services (GeoServer) SIG Rennes Metropole public (ZAC) et test (horaires)