### PR TITLE
Fix search and zoom by address and SIRENE name

### DIFF
--- a/addons/cartohoraires/config.json
+++ b/addons/cartohoraires/config.json
@@ -1,6 +1,7 @@
 {
     "js": [
-        "js/main.js"
+        "js/main.js",
+        "js/autocomplete.js"
     ],
     "css": "css/main.css",
     "html": "cartohoraires.html",

--- a/addons/cartohoraires/css/main.css
+++ b/addons/cartohoraires/css/main.css
@@ -123,3 +123,23 @@ input[type='radio']:after {
 	color:#353350;
 	font-weight: bold;
 }
+
+.autocomplete-list {
+	background-color:white;
+	position: absolute;
+	z-index: 1;
+	border: 1px #eeeeee solid;
+	border-radius: 4px;
+}
+
+.form-autocomplete {
+	margin-bottom: 0px;
+}
+
+.autocomplete {
+	padding: 0;
+}
+
+.top-form {
+	margin-bottom: 10px;
+}

--- a/addons/cartohoraires/js/autocomplete.js
+++ b/addons/cartohoraires/js/autocomplete.js
@@ -1,0 +1,113 @@
+
+
+class Autocomplete {
+    target = null;
+    search = null;
+    html = null;
+    listTarget = null;
+    /**
+     * Constructor
+     * @param {Object} map as ol.map object
+     */
+    constructor (target, list, search, html) {
+        this.target = target;
+        this.listTarget = list;
+        this.search = search;
+        this.html = html;
+    }
+
+    setSearch(func) {this.search = func;}
+    setTarget(func) {this.target = func;}
+    setListTarget(func) {this.listTarget = func;}
+    setHtml(func) {this.html = func;}
+    getSearch() {return this.search}
+    getHtml() {return this.html}
+    getListTarget() {return this.listTarget}
+    getTarget() {return this.target}
+
+    initListeners() {
+        let autocomplete = this;
+        let currentFocus;
+        /*execute a function when someone writes in the text field:*/
+        this.target.addEventListener("input", function(e) {
+            let val = e.target.value;
+            if (!val) { return false;}
+            currentFocus = -1;
+            /*close any already open lists of autocompleted values*/
+            autocomplete.closeAllLists();
+            /*Call API and display responses*/
+            if(autocomplete.search){
+                autocomplete.search(val);
+            }
+        });
+
+        /**
+        * Execute a function presses a key on the keyboard:
+        */
+        this.target.addEventListener("keydown", function(e) {
+            var x = document.getElementById(this.id + "autocomplete-list");
+            if (x) x = x.getElementsByTagName("div");
+            if (e.keyCode == 40) {
+                /*If the arrow DOWN key is pressed,
+                increase the currentFocus variable:*/
+                currentFocus++;
+                /*and and make the current item more visible:*/
+                addActive(x);
+            } else if (e.keyCode == 38) { //up
+                /*If the arrow UP key is pressed,
+                decrease the currentFocus variable:*/
+                currentFocus--;
+                /*and and make the current item more visible:*/
+                addActive(x);
+            } else if (e.keyCode == 13) {
+                /*If the ENTER key is pressed, prevent the form from being submitted,*/
+                e.preventDefault();
+                if (currentFocus > -1) {
+                    /*and simulate a click on the "active" item:*/
+                    if (x) x[currentFocus].click();
+                }
+            }
+        });
+    }
+
+    displayList = function (results) {
+        // parse results
+        if(this.html) {
+            this.listTarget.append(this.html(results));
+        }
+        
+        this.listTarget.show();
+    }
+
+    addActive(x) {
+        if (!x) return false;
+        /*start by removing the "active" class on all items:*/
+        removeActive(x);
+        if (currentFocus >= x.length) currentFocus = 0;
+        if (currentFocus < 0) currentFocus = (x.length - 1);
+        /*add class "autocomplete-active":*/
+        x[currentFocus].classList.add("autocomplete-active");
+    }
+    /**
+    * A function to remove the "active" class from all autocomplete items:
+    */
+    removeActive(x) {
+        for (var i = 0; i < x.length; i++) {
+            x[i].classList.remove("autocomplete-active");
+        }
+    }
+    /**
+    * Close all autocomplete lists in the document
+    */
+    closeAllLists = function () {
+        this.listTarget.empty();
+        this.listTarget.hide();
+    }
+
+    initCloseAction() { // to trigger
+        let autocomplete = this;
+        document.addEventListener("click", function (e) {
+            autocomplete.closeAllLists();
+        });
+    }
+}

--- a/addons/cartohoraires/templates/cartohoraires.mst
+++ b/addons/cartohoraires/templates/cartohoraires.mst
@@ -1,16 +1,17 @@
 <div class="cartohoraires-template container">
     <!--search area-->
-    <div class="row">
+    <div class="row top-form">
         <!--search field-->
-        <div class='col-sm-10 col-md-3' id="search-input">
-            <div class="form-group">
+        <div class='col-sm-10 col-md-3 autocomplete' id="search-input">
+            <div class="form-group form-autocomplete">
                 <div class='input-group date' id='ch-searchfield'>
                     <span class="input-group-addon search-picto">
                         <i class="fas fa-search"></i>
                     </span>
-                    <input type='text' class="form-control search-input" autocomplete="off"/>
+                    <input type='text' class="form-control search-input input-search input-text" autocomplete="off"/>
                 </div>
             </div>
+            <div class="autocomplete-list col-sm-12" style="display:none;"></div>
         </div>
         <!--search radio-->
         <div class="col-sm-10 col-md-4" id="search-radio">


### PR DESCRIPTION
Lié à #20 et #37.

Permet de rechercher dans la base SIRENE et la base Adresse BAN et de peuper les infos dans le template.

Le comportement permet : 
- Choisir entre une recherche par adresse ou SIRENE vu dans #20 
- Zoom sur un niveau prédéfini, qui devra être configurable (TODO)
- Après le zoom, permet de peupler le volet d'informations selon la ZAC contenue sous le centre de la map ou selon les données de l'emprise comme vu dans #24 et #37